### PR TITLE
Compatibility with Python >3.6 on Windows

### DIFF
--- a/aiogevent.py
+++ b/aiogevent.py
@@ -9,7 +9,7 @@ import threading
 try:
     import asyncio
 
-    if sys.platform == 'win32':
+    if sys.platform == 'win32' and sys.version_info.minor <= 6:
         from asyncio.windows_utils import socketpair
     else:
         socketpair = socket.socketpair


### PR DESCRIPTION
In python 3.7, `asyncio.windows_utils.socketpair` does not exist anymore - it is just replaced by `socket.socketpair`